### PR TITLE
Add PracHub to Technical Interviewing resources

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -280,6 +280,7 @@ permalink: /resources/
 - [BinarySearch](https://binarysearch.com/) (collaborative)
 - [Pramp](https://www.pramp.com/#/) (mock technical interviews)
 - [AlgoExpert](https://www.algoexpert.io/)
+- [PracHub](https://prachub.com/) (practice real interview questions from 400+ companies; coding, SQL, system design, behavioral)
 - [Cracking the Coding Interview by Gayle Laakmann McDowell](https://www.crackingthecodinginterview.com/) (book)
 - [Instructions for the interviewer](https://hackmd.io/ekflQ-myQv6_0r7bsxGbgQ#) (good reference for what interviewers are thinking)
 - [Tech Interview Handbook](https://techinterviewhandbook.org/)


### PR DESCRIPTION
Adds **PracHub** (https://prachub.com) to the Technical Interviewing list, alongside Leetcode, Neetcode, AlgoExpert, and interviewing.io.

**Disclosure: I'm affiliated with PracHub.**

It's a free platform for practicing real interview questions from 400+ companies (coding/DSA, SQL, system design, behavioral) with an in-browser coding console — same category as the other entries here. Happy to adjust wording/placement or close if it's not a fit for your list. Thanks for maintaining this!